### PR TITLE
Cosmetic and dependence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Info.plist
 Makefile*
 *.user
 qtc-gdbmacros
+.qmake.stash

--- a/README.fedora.md
+++ b/README.fedora.md
@@ -3,8 +3,16 @@ Fedora-specific Build/Setup Instructions
 
 Install build-dependencies:
 
+Prior to Fedora 33
+
     sudo dnf install \
         qt5-devel libgcrypt-devel libmad-devel \
+        libid3tag-devel glib-devel taglib-devel
+
+Fedora 33+
+
+    sudo dnf install \
+        qt5-qtbase-devel libgcrypt-devel libmad-devel \
         libid3tag-devel glib-devel taglib-devel
 
 Symlink translation tools:


### PR DESCRIPTION
- Moving README.fedora to README.fedora.md for correct display in github
- Adding .qmake.stash to .gitignore
- Before Fedora 33, the qt5-devel package exists. It is replaced by qt5-qtbase-devel since then